### PR TITLE
新增：允许在cookie模式下自己设置服务器地址

### DIFF
--- a/app/src/main/kotlin/website/xihan/pbra/utils/Settings.kt
+++ b/app/src/main/kotlin/website/xihan/pbra/utils/Settings.kt
@@ -37,10 +37,12 @@ object Settings {
     const val HK_BASE_URL = "https://public-heart-rate-api.xihan.website"
     const val CLOUD_FLARE_BASE_URL = "https://public-heart-rate-api.xihan.lat"
 
-    fun getSelectedBaseUrl() = if (baseUrlIndex == 0) {
-        HK_BASE_URL
-    } else {
-        CLOUD_FLARE_BASE_URL
+    fun getSelectedBaseUrl(): String {
+        return if (baseUrl.isNotBlank()) {
+            baseUrl
+        } else {
+            if (baseUrlIndex == 0) HK_BASE_URL else CLOUD_FLARE_BASE_URL
+        }
     }
 
     fun getSelectedBaseUrlText() = if (baseUrlIndex == 0) {


### PR DESCRIPTION
###  新功能说明

- 允许在 Cookie 模式下使用“完整地址输入框”填写服务器地址
- 未填写时仍根据 baseUrlIndex 使用内置香港/Cloudflare 地址

###  已测试内容
- 直链和 Cookie 模式均可正常切换
- 未填写时使用内置地址逻辑正常
- 与原有 UI 兼容，无新增控件

> heart-rate-server项目的README忘记更新了啊喂 写着`填入模块时记得要去掉receive_data` 然后去掉就寄了 自己试着改了一下内置服务器的地址发现是ok的 故出现了本次pr